### PR TITLE
Dev-dependency `cross-env` added

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,6 +123,7 @@
     "babel-plugin-react-intl-auto": "^3.3.0",
     "babel-plugin-require-context-hook": "^1.0.0",
     "clean-webpack-plugin": "^3.0.0",
+    "cross-env": "^7.0.3",
     "css-loader": "^1.0.0",
     "cypress": "^4.12.1",
     "dotenv": "^8.2.0",


### PR DESCRIPTION
Needed to launch locally on vanilla Ubuntu 20.10

I want to merge this change because...

otherwise `npm start` complains of missing `cross-env`

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] Changes are mentioned in the changelog.

### Test Environment Config

<!-- Do not remove this section. It is required to properly setup test instance.
Modify API_URI if you want test instance to use custom backend. -->

API_URI=https://master.staging.saleor.rocks/graphql/
